### PR TITLE
wrap link and query objects in a proxy

### DIFF
--- a/lib/teamsnap_rb.rb
+++ b/lib/teamsnap_rb.rb
@@ -5,6 +5,7 @@ require "teamsnap_rb/version"
 
 require "teamsnap_rb/auth"
 require "teamsnap_rb/request_builder"
+require "teamsnap_rb/link"
 require "teamsnap_rb/links_proxy"
 require "teamsnap_rb/queries_proxy"
 require "teamsnap_rb/item"

--- a/lib/teamsnap_rb/link.rb
+++ b/lib/teamsnap_rb/link.rb
@@ -1,0 +1,24 @@
+module TeamsnapRb
+  class Link
+    def initialize(link, auth)
+      self.auth = auth
+      self.link = link
+    end
+
+    def follow
+      @collection ||= Collection.new(href, auth)
+    end
+
+    def rel
+      link.rel
+    end
+
+    def href
+      link.href
+    end
+
+    private
+
+    attr_accessor :auth, :link
+  end
+end


### PR DESCRIPTION
to make it easier for users to see what links and queries are available I added back the links and queries methods on collection. That returns the links proxy that is now an enumerable. The problem is the each yields the collection-json link object but that leaks the abstraction through.

So we need a discoverable way to browse with the gem.
