### PR TITLE
Converts keyword arguments to options hashes to make teamsnap_rb compatible with ruby 1.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     teamsnap_rb (0.0.3)
-      conglomerate (~> 0.8.0)
+      conglomerate (>= 0.15.0)
       faraday (~> 0.9.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
-    conglomerate (0.8.1)
+    conglomerate (0.15.0)
     diff-lcs (1.2.5)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)

--- a/lib/teamsnap_rb.rb
+++ b/lib/teamsnap_rb.rb
@@ -5,7 +5,6 @@ require "securerandom"
 
 require "teamsnap_rb/version"
 require "teamsnap_rb/exceptions"
-
 require "teamsnap_rb/config"
 require "teamsnap_rb/request_builder"
 require "teamsnap_rb/link"
@@ -14,10 +13,8 @@ require "teamsnap_rb/queries_proxy"
 require "teamsnap_rb/item"
 require "teamsnap_rb/template"
 require "teamsnap_rb/models/event"
-
 require "teamsnap_rb/collection"
 require "teamsnap_rb/client"
 
 module TeamsnapRb
-
 end

--- a/lib/teamsnap_rb/client.rb
+++ b/lib/teamsnap_rb/client.rb
@@ -1,6 +1,7 @@
 module TeamsnapRb
   class Client < Collection
-    def initialize(url = "https://apiv3.teamsnap.com/", config: Config.new)
+    def initialize(url = "https://apiv3.teamsnap.com/", options = {})
+      config = options.fetch(:config, Config.new)
       super(url, {}, config)
     end
   end

--- a/lib/teamsnap_rb/collection.rb
+++ b/lib/teamsnap_rb/collection.rb
@@ -8,7 +8,9 @@ module TeamsnapRb
       "Event" => Event
     }
 
-    def initialize(url, query_parameters, config, request: nil)
+    def initialize(url, query_parameters, config, options = {})
+      request = options.fetch(:request, nil)
+
       self.config = config
       data = request || get(url, query_parameters)
       self.errors = []

--- a/lib/teamsnap_rb/config.rb
+++ b/lib/teamsnap_rb/config.rb
@@ -2,10 +2,10 @@ module TeamsnapRb
   class Config
     attr_accessor :access_token, :client_id, :client_secret, :request_middleware, :response_middleware
 
-    def initialize(access_token: nil, client_id: nil, client_secret: nil)
-      self.access_token = access_token
-      self.client_secret = client_secret
-      self.client_id = client_id
+    def initialize(options = {})
+      self.access_token = options.fetch(:access_token, nil)
+      self.client_secret = options.fetch(:client_secret, nil)
+      self.client_id = options.fetch(:client_id, nil)
       self.response_middleware = []
       self.request_middleware = []
     end

--- a/lib/teamsnap_rb/models/user.rb
+++ b/lib/teamsnap_rb/models/user.rb
@@ -1,5 +1,4 @@
 module TeamsnapRb
   class User
-
   end
 end

--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
   spec.description   = %q{}
   spec.homepage      = "http://www.teamsnap.com/api"
   spec.license       = "MIT"
-  spec.required_ruby_version = '>= 1.8.6'
-  
+  spec.required_ruby_version = '>= 1.9.3'
+
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", ">= 3.0.0"
 
   spec.add_dependency "faraday", "~> 0.9.0"
-  spec.add_dependency "conglomerate", "~> 0.8.0"
+  spec.add_dependency "conglomerate", ">= 0.15.0"
 end


### PR DESCRIPTION
Also updates the gemspec required ruby version and the dependency on the 1.9 compatible version of conglomerate.
