### PR TITLE
Relax constraint on Oj version

### DIFF
--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday",  "~> 0.9.1"
   spec.add_dependency "typhoeus", "~> 0.7.1"
-  spec.add_dependency "oj",       "~> 2.11.4"
+  spec.add_dependency "oj",       "~> 2.11"
   spec.add_dependency "inflecto", "~> 0.0.2"
   spec.add_dependency "virtus",   "~> 1.0.4"
 end


### PR DESCRIPTION
The version constraint here seems to be a bit too restrictive. Loosening up to
be able to optimistically upgrade on minor versions.
