### PR TITLE
fail silently on init, and loudly on subsequent calls to API

### DIFF
--- a/lib/teamsnap.rb
+++ b/lib/teamsnap.rb
@@ -6,7 +6,6 @@ require "inflecto"
 require "virtus"
 require "date"
 require "securerandom"
-require "pry"
 
 require_relative "teamsnap/version"
 


### PR DESCRIPTION
deploys and codeship should be able to initialize the application without relying on this connection