### PR TITLE
Fixes #76 Use token auth as primary example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _Note: You'll need an OAuth2 Token from TeamSnap. Checkout our API docs
 
     λ gem install teamsnap_rb
     λ irb
-    TeamSnap.init(:client_id => XXXXX, :client_secret => XXXXX)
+    TeamSnap.init(:token => XXXXX)
     => true
 
     # Now you have your base connection to the API under:


### PR DESCRIPTION
Majority of use will use token auth, and the token is mentioned in the initial "note" at the beginning of the usage section.