### PR TITLE
load items for root objects

### DIFF
--- a/lib/teamsnap/collection.rb
+++ b/lib/teamsnap/collection.rb
@@ -86,6 +86,10 @@ module TeamSnap
         .map{ |col| col.fetch(:name) }
     end
 
+    def items
+      @items ||= TeamSnap::Item.load_items(TeamSnap.root_client, parsed_collection)
+    end
+
     def href
       self.instance_variable_get(:@href)
     end


### PR DESCRIPTION
if a collection is one of our root endpoints, like sports make those
  items available on the class. This puts them:

```
TeamSnap::Sport.items
```