### PR TITLE
update oj build to 2.18.1 from 2.11.4

### DIFF
--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday",  "~> 0.9.1"
   spec.add_dependency "typhoeus", "~> 0.7.1"
-  spec.add_dependency "oj",       "~> 2.11.4"
+  spec.add_dependency "oj",       "~> 2.18.1"
   spec.add_dependency "inflecto", "~> 0.0.2"
   spec.add_dependency "virtus",   "~> 1.0.4"
 end


### PR DESCRIPTION
bundle install fails with 2.11.4, works without issue with the latest build 2.18.1