### PR TITLE
fix so that OJ can properly parse ActiveSupport::TimeWithZone

### DIFF
--- a/lib/config/oj.rb
+++ b/lib/config/oj.rb
@@ -1,5 +1,6 @@
 Oj.default_options = {
   :mode => :compat,
   :symbol_keys => true,
-  :class_cache => true
+  :class_cache => true,
+  :use_as_json => true
 }

--- a/lib/teamsnap/version.rb
+++ b/lib/teamsnap/version.rb
@@ -1,3 +1,3 @@
 module TeamSnap
-  VERSION = "2.0.0.beta13"
+  VERSION = "2.0.0.beta14"
 end


### PR DESCRIPTION
```ruby

# before
> t = Time.zone.now

> Oj.dump(time: t)
=> "{\"time\":{\"utc\":1490886659.366070000e86400,\"time\":1490886659.366070000e86400,\"time_zone\":{\"name\":\"UTC\",\"utc_offset\":null,\"tzinfo\":{\"info\":{\"identifier\":\"Etc/UTC\",\"offsets\":{\"0\":{\"utc_offset\":0,\"std_offset\":0,\"abbreviation\":\"UTC\",\"utc_total_offset\":0}},\"transitions\":[],\"previous_offset\":{\"utc_offset\":0,\"std_offset\":0,\"abbreviation\":\"UTC\",\"utc_total_offset\":0},\"transitions_index\":null}}},\"period\":{\"start_transition\":null,\"end_transition\":null,\"offset\":{\"utc_offset\":0,\"std_offset\":0,\"abbreviation\":\"UTC\",\"utc_total_offset\":0},\"utc_total_offset_rational\":null}}}"

#after
> Oj.dump(time: t)
"{\"time\":\"2017-03-30T15:10:59.366Z\"}"