### PR TITLE
Handle 204 responses and loosen gem restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,8 @@ v2.0.0
 ------
 
 - Update some of the out of date gem dependencies.
+
+[v2.1.3]()
+------
+
+- Update some of the out of date gem dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ v2.0.0
 
 - Update some of the out of date gem dependencies.
 
-[v2.1.3]()
+[v2.1.3](https://github.com/teamsnap/teamsnap_rb/pull/104)
 ------
 
 - Update some of the out of date gem dependencies.
+- Handle 204 responses with no body

--- a/lib/teamsnap.rb
+++ b/lib/teamsnap.rb
@@ -58,7 +58,9 @@ module TeamSnap
     def run(client, via, href, args = {}, &block)
       timeout_error = block || default_timeout_error
       resp = client_send(client, via, href, args)
-      return TeamSnap::Response.load_collection(resp)
+      unless resp.status == 204
+        TeamSnap::Response.load_collection(resp)
+      end
     rescue Faraday::TimeoutError
       timeout_error.call
     end

--- a/lib/teamsnap/collection.rb
+++ b/lib/teamsnap/collection.rb
@@ -32,7 +32,9 @@ module TeamSnap
           end
 
           resp = TeamSnap.run(client, via, href, args)
-          TeamSnap::Item.load_items(client, resp)
+          if resp
+            TeamSnap::Item.load_items(client, resp)
+          end
         end
       end
     end

--- a/lib/teamsnap/version.rb
+++ b/lib/teamsnap/version.rb
@@ -1,3 +1,3 @@
 module TeamSnap
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end

--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec",   "~> 3.6.0"
   spec.add_development_dependency "vcr",     "~> 2.9.3"
 
-  spec.add_dependency "faraday",  "~> 0.11.0"
+  spec.add_dependency "faraday",  ">= 0.11.0"
   spec.add_dependency "typhoeus", "~> 1.1.2"
   spec.add_dependency "oj",       "~> 2.18.5"
   spec.add_dependency "inflecto", "~> 0.0.2"

--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday",  ">= 0.11.0"
   spec.add_dependency "typhoeus", "~> 1.1.2"
-  spec.add_dependency "oj",       "~> 2.18.5"
+  spec.add_dependency "oj",       ">= 2.18.5"
   spec.add_dependency "inflecto", "~> 0.0.2"
   spec.add_dependency "virtus",   "~> 1.0.4"
 end


### PR DESCRIPTION
This update allows 204 responses that have no JSON to parse to proceed.