### PR TITLE
Update Rack version to address CVE-2018-16471

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ before_install:
   - "find /home/travis/.rvm/rubies -wholename '*default/bundler-*.gemspec' -delete"
   - gem install bundler -v 1.15.1
 rvm:
-  - 2.0.0
   - 2.1.5
   - 2.2.0
-  - 2.3.3
+  - 2.3.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,3 +70,8 @@ v2.0.0
 ------
 
 - Update some of the out of date gem dependencies.
+
+[v2.1.3](https://github.com/teamsnap/teamsnap_rb/pull/)
+------
+
+- Update Rack dependency to patch CVE-2018-16471

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,12 @@ v2.0.0
 
 - Update some of the out of date gem dependencies.
 
-[v2.1.3](https://github.com/teamsnap/teamsnap_rb/pull/)
+[v2.1.2](https://github.com/teamsnap/teamsnap_rb/pull/103)
+------
+
+- Update plural inflection for `partner_preferences`
+
+[v2.1.3](https://github.com/teamsnap/teamsnap_rb/pull/106)
 ------
 
 - Update Rack dependency to patch CVE-2018-16471

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "simplecov", "0.14.1", :require => false
 gem "coveralls", "0.8.21", :require => false
 gem "pry", :require => false
 gem "rack-test", "0.7.0", :require => false
-gem "rack", "1.6.4", :require => false
+gem "rack", ">= 1.6.11", :require => false
 gem "awesome_print"
 
 gemspec

--- a/lib/teamsnap/version.rb
+++ b/lib/teamsnap/version.rb
@@ -1,3 +1,3 @@
 module TeamSnap
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end


### PR DESCRIPTION
GitHub posted a security alert for the use of Rack

https://github.com/teamsnap/teamsnap_rb/network/alert/Gemfile/rack/open

This update patches that issue and does some cleanup.

