### PR TITLE
Remove Oj and update faraday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,4 @@ v2.0.0
 ------
 
 - Remove Oj gem dependency
+- Update faraday dependency to allow version 0.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,3 +99,8 @@ v2.0.0
 - Update typhoeus from 1.1 to 1.3
 - Update rspec from 3.6 to 3.8
 - Update vcr from 2.9 to 5.0
+
+[v2.4.0](https://github.com/teamsnap/teamsnap_rb/pull/111)
+------
+
+- Remove Oj gem dependency

--- a/lib/config/oj.rb
+++ b/lib/config/oj.rb
@@ -1,6 +1,0 @@
-Oj.default_options = {
-  :mode => :compat,
-  :symbol_keys => true,
-  :class_cache => true,
-  :use_as_json => true
-}

--- a/lib/teamsnap.rb
+++ b/lib/teamsnap.rb
@@ -1,10 +1,10 @@
 %w(
-    faraday typhoeus typhoeus/adapters/faraday oj inflecto virtus
+    faraday typhoeus typhoeus/adapters/faraday inflecto virtus
     date securerandom
   ).each { |x| require x }
 
 %w(
-    config/inflecto config/oj teamsnap/version teamsnap/api
+    config/inflecto teamsnap/version teamsnap/api
     teamsnap/auth_middleware teamsnap/client teamsnap/collection teamsnap/item
     teamsnap/response teamsnap/structure
   ).each { |x| require_relative x }
@@ -79,7 +79,7 @@ module TeamSnap
           if use_multipart?(args)
             req.body = args
           else
-            req.body = Oj.dump(args)
+            req.body = JSON.generate(args)
           end
         end
       else

--- a/lib/teamsnap/api.rb
+++ b/lib/teamsnap/api.rb
@@ -76,7 +76,7 @@ module TeamSnap
       return "Forbidden (403)" if resp.status == 403 && resp.body == ""
 
       begin
-        Oj.load(resp.body)
+        JSON.parse(resp.body)
           .fetch(:collection)
           .fetch(:error)
           .fetch(:message)

--- a/lib/teamsnap/api.rb
+++ b/lib/teamsnap/api.rb
@@ -76,7 +76,7 @@ module TeamSnap
       return "Forbidden (403)" if resp.status == 403 && resp.body == ""
 
       begin
-        JSON.parse(resp.body)
+        JSON.parse(resp.body, :symbolize_names => true)
           .fetch(:collection)
           .fetch(:error)
           .fetch(:message)

--- a/lib/teamsnap/collection.rb
+++ b/lib/teamsnap/collection.rb
@@ -106,7 +106,7 @@ module TeamSnap
     def parse_collection
       if resp
         TeamSnap.response_check(resp, :get)
-        collection = JSON.parse(resp.body).fetch(:collection) { [] }
+        collection = JSON.parse(resp.body, :symbolize_names => true).fetch(:collection) { [] }
       elsif parsed_collection
         collection = parsed_collection
       end

--- a/lib/teamsnap/collection.rb
+++ b/lib/teamsnap/collection.rb
@@ -106,7 +106,7 @@ module TeamSnap
     def parse_collection
       if resp
         TeamSnap.response_check(resp, :get)
-        collection = Oj.load(resp.body).fetch(:collection) { [] }
+        collection = JSON.parse(resp.body).fetch(:collection) { [] }
       elsif parsed_collection
         collection = parsed_collection
       end

--- a/lib/teamsnap/response.rb
+++ b/lib/teamsnap/response.rb
@@ -4,7 +4,7 @@ module TeamSnap
     class << self
       def load_collection(resp)
         if resp.success?
-          return Oj.load(resp.body).fetch(:collection)
+          return JSON.parse(resp.body).fetch(:collection)
         else
           content_type = resp.headers["content-type"]
           if content_type && content_type.match("json")
@@ -69,14 +69,14 @@ module TeamSnap
     end
 
     def process_info
-      body = Oj.load(@resp.body)
+      body = JSON.parse(@resp.body)
       @collection = body.fetch(:collection) { {} }
       @message = "Data retrieved successfully"
       @objects = TeamSnap::Item.load_items(@client, @collection)
     end
 
     def process_action
-      body = Oj.load(@resp.body) || {}
+      body = JSON.parse(@resp.body) || {}
       @collection = body.fetch(:collection) { {} }
       @message = "`#{@via}` call was successful"
       @objects = TeamSnap::Item.load_items(@client, @collection)
@@ -84,7 +84,7 @@ module TeamSnap
 
     def process_error
       if @resp.headers["content-type"].match("json")
-        body = Oj.load(@resp.body) || {}
+        body = JSON.parse(@resp.body) || {}
         @collection = body.fetch(:collection) { {} }
         @message = TeamSnap::Api.parse_error(@resp)
         @objects = TeamSnap::Item.load_items(@client, @collection)

--- a/lib/teamsnap/response.rb
+++ b/lib/teamsnap/response.rb
@@ -4,7 +4,7 @@ module TeamSnap
     class << self
       def load_collection(resp)
         if resp.success?
-          return JSON.parse(resp.body).fetch(:collection)
+          return JSON.parse(resp.body, :symbolize_names => true).fetch(:collection)
         else
           content_type = resp.headers["content-type"]
           if content_type && content_type.match("json")
@@ -69,14 +69,14 @@ module TeamSnap
     end
 
     def process_info
-      body = JSON.parse(@resp.body)
+      body = JSON.parse(@resp.body, :symbolize_names => true)
       @collection = body.fetch(:collection) { {} }
       @message = "Data retrieved successfully"
       @objects = TeamSnap::Item.load_items(@client, @collection)
     end
 
     def process_action
-      body = JSON.parse(@resp.body) || {}
+      body = JSON.parse(@resp.body, :symbolize_names => true) || {}
       @collection = body.fetch(:collection) { {} }
       @message = "`#{@via}` call was successful"
       @objects = TeamSnap::Item.load_items(@client, @collection)
@@ -84,7 +84,7 @@ module TeamSnap
 
     def process_error
       if @resp.headers["content-type"].match("json")
-        body = JSON.parse(@resp.body) || {}
+        body = JSON.parse(@resp.body, :symbolize_names => true) || {}
         @collection = body.fetch(:collection) { {} }
         @message = TeamSnap::Api.parse_error(@resp)
         @objects = TeamSnap::Item.load_items(@client, @collection)

--- a/lib/teamsnap/structure.rb
+++ b/lib/teamsnap/structure.rb
@@ -34,7 +34,7 @@ module TeamSnap
 
         href_to_rel = Hash[*href_to_rel.flatten]
 
-        Oj.load(response.body)
+        JSON.parse(response.body)
           .map { |collection|
             col = collection.fetch(:collection) { {} }
             if rel = href_to_rel[col[:href]]

--- a/lib/teamsnap/structure.rb
+++ b/lib/teamsnap/structure.rb
@@ -34,7 +34,7 @@ module TeamSnap
 
         href_to_rel = Hash[*href_to_rel.flatten]
 
-        JSON.parse(response.body)
+        JSON.parse(response.body, :symbolize_names => true)
           .map { |collection|
             col = collection.fetch(:collection) { {} }
             if rel = href_to_rel[col[:href]]

--- a/lib/teamsnap/version.rb
+++ b/lib/teamsnap/version.rb
@@ -1,3 +1,3 @@
 module TeamSnap
-  VERSION = "2.3.1"
+  VERSION = "2.4.0"
 end

--- a/spec/teamsnap/apiv_spec.rb
+++ b/spec/teamsnap/apiv_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "teamsnap__api", :vcr => true do
     it "returns a proper error message" do
       response = Faraday::Response.new(
         :status => 403,
-        :body => Oj.dump("collection" => { :error => { :message => "Error Message"}})
+        :body => JSON.generate("collection" => { :error => { :message => "Error Message"}})
       )
       expect(TeamSnap::Api.parse_error(response)).to eq("Error Message")
     end

--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec",   "~> 3.8.0"
   spec.add_development_dependency "vcr",     "~> 5.0.0"
 
-  spec.add_dependency "faraday",  "~> 0.15.0"
+  spec.add_dependency "faraday",  "~> 0.17", "< 1.0"
   spec.add_dependency "typhoeus", "~> 1.3.0"
   spec.add_dependency "inflecto", "~> 0.0.2"
   spec.add_dependency "virtus",   "~> 1.0.4"

--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday",  "~> 0.15.0"
   spec.add_dependency "typhoeus", "~> 1.3.0"
-  spec.add_dependency "oj",       "~> 3.9.0"
   spec.add_dependency "inflecto", "~> 0.0.2"
   spec.add_dependency "virtus",   "~> 1.0.4"
 end


### PR DESCRIPTION
On Ruby 2+ Oj should not be required, JSON is provided by the stdlib. Inspired by https://www.mikeperham.com/2016/02/09/kill-your-dependencies/