### PR TITLE
Migrate CI from travis to GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - run: gem install bundler -v 1.17.3
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [ '2.3.8', '2.4.10', '2.5.8', '2.6.8' ]
+        ruby: [ '2.3.8', '2.4.10', '2.5.8', '2.6.6' ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby: [ '2.3.8', '2.4.10', '2.5.8', '2.6.8' ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       matrix:
         ruby: [ '2.3.8', '2.4.10', '2.5.8', '2.6.6' ]
+      max-parallel: 1
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+      - run: gem install bundler -v 1.17.3
       - name: Install dependencies
         run: bundle install
       - name: Run tests

--- a/.teamsnap/service.yml
+++ b/.teamsnap/service.yml
@@ -2,12 +2,13 @@
 classification: lib
 production:
   tier: 1
-  url: 
-  hosting_platform: 
+  url:
+  hosting_platform:
 performance_monitoring: []
 error_monitoring: []
 continuous_integration:
-  - name: travis-ci
+  - name: github_actions
+    reference_id: CI
 bug_tracking: []
 documentation: []
 deployment: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-before_install:
-  - gem install bundler -v 1.17.3
-script: bundle exec rspec spec
-rvm:
-  - 2.3.8
-  - 2.4.10
-  - 2.5.8
-  - 2.6.6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # teamsnap_rb
 
-
+![CI](https://github.com/teamsnap/teamsnap_rb/workflows/CI/badge.svg)
 [![Gem Version](https://badge.fury.io/rb/teamsnap_rb.svg)](https://badge.fury.io/rb/teamsnap_rb)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # teamsnap_rb
 
-[![Build](https://travis-ci.org/teamsnap/teamsnap_rb.svg?branch=master)](https://travis-ci.org/teamsnap/teamsnap_rb)
+
 [![Gem Version](https://badge.fury.io/rb/teamsnap_rb.svg)](https://badge.fury.io/rb/teamsnap_rb)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 

--- a/teamsnap_rb.gemspec
+++ b/teamsnap_rb.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", ">= 1.17.3"
   spec.add_development_dependency "rspec",   "~> 3.9"
   spec.add_development_dependency "vcr",     "~> 5.0"
 


### PR DESCRIPTION
This update migrates from travis to GH Actions because [travis-ci.org for Open Source projects is migrating to travis-ci.com requiring paid plans.](https://docs.travis-ci.com/user/migrate/open-source-repository-migration/#frequently-asked-questions).