### PR TITLE
Move middleware setup to after calling super

### DIFF
--- a/lib/teamsnap/auth_middleware.rb
+++ b/lib/teamsnap/auth_middleware.rb
@@ -3,8 +3,8 @@ require 'openssl'
 module TeamSnap
   class AuthMiddleware < Faraday::Middleware
     def initialize(app, options)
-      @options = options
       super(app)
+      @options = options
     end
 
     def call(env)

--- a/lib/teamsnap/version.rb
+++ b/lib/teamsnap/version.rb
@@ -1,3 +1,3 @@
 module TeamSnap
-  VERSION = "3.0.1"
+  VERSION = "3.0.4"
 end


### PR DESCRIPTION
Seems like teamsnap_rb 3 is not working on fresh installs.

to reproduce

```
source "https://rubygems.org"

gem "teamsnap_rb", "~> 3.0"
```

```ruby
require "teamsnap"
token = "[my token]"
team_id = [team id]
TeamSnap.init(token: token)
client = TeamSnap.root_client
t = TeamSnap::Team.find(client, team_id)
puts t.name
```

results in :

```bash
.gem/ruby/3.2.2/gems/teamsnap_rb-3.0.3/lib/teamsnap/response.rb:16:in `load_collection': You are not authorized to access this resource. Please ensure you've provided a valid access token. (TeamSnap::Error)
	from .gem/ruby/3.2.2/gems/teamsnap_rb-3.0.3/lib/teamsnap.rb:65:in `run'
	from .gem/ruby/3.2.2/gems/teamsnap_rb-3.0.3/lib/teamsnap/collection.rb:34:in `block in register_endpoint'
	from .gem/ruby/3.2.2/gems/teamsnap_rb-3.0.3/lib/teamsnap/collection.rb:122:in `block in enable_find'
	from app.rb:30:in `<main>'
```

To troubleshoot, I first tried to reproduce with a curl request directly against the API, but that still works fine.

After adding a proxy server, I noticed that the gem isn't setting the `Authorization` header. In looking further, I [noticed most middleware examples set options after super](https://github.com/lostisland/faraday_middleware/tree/main/lib/faraday_middleware). Looking at the history of the base `Faraday::Middleware` class I found [this change added `@options`](https://github.com/lostisland/faraday/pull/1194) to the base class which overwrites the auth middleware's options when super is called last.

sorry, didn't write a spec, I'll leave that you all 😄 